### PR TITLE
Add `build-tools: hsc2hs`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230321
+# version: 0.16.6.20230729
 #
-# REGENDATA ("0.15.20230321",["github","filelock.cabal"])
+# REGENDATA ("0.16.6.20230729",["github","filelock.cabal"])
 #
 name: Haskell-CI
 on:
@@ -36,19 +36,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.4
+          - compiler: ghc-9.4.5
             compilerKind: ghc
-            compilerVersion: 9.4.4
+            compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -81,6 +81,11 @@ jobs:
             compilerVersion: 8.2.2
             setup-method: hvr-ppa
             allow-failure: false
+          - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -89,7 +94,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -98,7 +103,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -176,8 +181,8 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
@@ -207,8 +212,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_filelock}" >> cabal.project
-          echo "package filelock" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package filelock" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(filelock)$/; }' >> cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 Changelog for filelock package
 
+0.1.1.7
+-------
+
+_2023-08-03, Andreas Abel_
+
+* Add `build-tools: hsc2hs` to `.cabal` for building with GHC 8.x
+
+Tested with GHC 8.0 - 9.8.1-alpha1.
+
 0.1.1.6
 -------
 

--- a/filelock.cabal
+++ b/filelock.cabal
@@ -17,15 +17,16 @@ extra-source-files:
   tests/lock.log.expected
 
 tested-with:
-  GHC == 9.6.1
-  GHC == 9.4.4
-  GHC == 9.2.7
+  GHC == 9.6.2
+  GHC == 9.4.5
+  GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
   GHC == 8.6.5
   GHC == 8.4.4
   GHC == 8.2.2
+  GHC == 8.0.2
 
 library
   hs-source-dirs:      .

--- a/filelock.cabal
+++ b/filelock.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                filelock
-version:             0.1.1.6
+version:             0.1.1.7
 synopsis:            Portable interface to file locking (flock / LockFileEx)
 description:         This package provides an interface to Windows and Unix
                      file locking functionalities.
@@ -33,8 +33,10 @@ library
   exposed-modules:     System.FileLock
   other-modules:       System.FileLock.Internal.Flock
                        System.FileLock.Internal.LockFileEx
-  build-depends:       base >=4.9.0.0 && <5
   default-language:    Haskell2010
+
+  build-depends:       base >=4.9.0.0 && <5
+  build-tools:         hsc2hs
 
   ghc-options:        -Wall
   if os(windows)


### PR DESCRIPTION
- Bump CI to GHC 9.6.2, 9.4.5 and 9.2.8; add 8.0.2
- 0.1.1.7: add `build-tools: hsc2hs` for building with GHC 8.x

https://hackage.haskell.org/package/filelock-0.1.1.7/candidate

This PR fixes the following problem when building with GHC 8.x:
```
$ cabal-3.6.2 build -w ghc-8.0.2
...
Preprocessing library for filelock-0.1.1.6..
cabal: The program 'hsc2hs' is required but it could not be found.
```